### PR TITLE
Fixed context warnings (v0.12)

### DIFF
--- a/slydst.typ
+++ b/slydst.typ
@@ -15,32 +15,28 @@
   date: none,
   authors: (),
   layout: "medium",
-  ratio: 4/3,
+  ratio: 4 / 3,
   title-color: none,
 ) = {
-
   // Parsing
   if layout not in layouts {
-      panic("Unknown layout " + layout)
+    panic("Unknown layout " + layout)
   }
   let (height, space) = layouts.at(layout)
   let width = ratio * height
 
   // Colors
   if title-color == none {
-      title-color = default-color
+    title-color = default-color
   }
 
   // Setup
-  set document(
-    title: title,
-    author: authors,
-  )
+  set document(title: title, author: authors)
   set page(
     width: width,
     height: height,
     margin: (x: 0.5 * space, top: space, bottom: 0.6 * space),
-    header: context {
+    header: context{
       let page = here().page()
       let headings = query(selector(heading.where(level: 2)))
       let heading = headings.rev().find(x => x.location().page() <= page)
@@ -48,28 +44,21 @@
         set align(top)
         set text(1.4em, weight: "bold", fill: title-color)
         v(space / 2)
-        block(heading.body +
-          if not heading.location().page() == page [
-            #{numbering("(i)", page - heading.location().page() + 1)}
-          ]
-        )
+        block(heading.body + if not heading.location().page() == page [
+          #{ numbering("(i)", page - heading.location().page() + 1) }
+        ])
       }
     },
     header-ascent: 0%,
     footer: [
       #set text(0.8em)
       #set align(right)
-      #counter(page).display("1/1", both: true)
+      #context counter(page).display("1/1", both: true)
     ],
     footer-descent: 0.8em,
   )
-  set outline(
-    target: heading.where(level: 1),
-    title: none,
-  )
-  set bibliography(
-    title: none
-  )
+  set outline(target: heading.where(level: 1), title: none)
+  set bibliography(title: none)
 
   // Rules
   show heading.where(level: 1): x => {
@@ -85,8 +74,7 @@
   // Title
   if (title == none) {
     panic("A title is required")
-  }
-  else {
+  } else {
     if (type(authors) != array) {
       authors = (authors,)
     }
@@ -94,13 +82,7 @@
     set align(horizon)
     v(- space / 2)
     block(
-      text(2.0em, weight: "bold", fill: title-color, title) +
-      v(1.4em, weak: true) +
-      if subtitle != none { text(1.1em, weight: "bold", subtitle) } +
-      if subtitle != none and date != none { text(1.1em)[ \- ] } +
-      if date != none {text(1.1em, date)} +
-      v(1em, weak: true) +
-      align(left, authors.join(", ", last: " and "))
+      text(2.0em, weight: "bold", fill: title-color, title) + v(1.4em, weak: true) + if subtitle != none { text(1.1em, weight: "bold", subtitle) } + if subtitle != none and date != none { text(1.1em)[ \- ] } + if date != none { text(1.1em, date) } + v(1em, weak: true) + align(left, authors.join(", ", last: " and ")),
     )
   }
 
@@ -109,15 +91,12 @@
 }
 
 #let frame(content, counter: none, title: none) = {
-
   let header = none
   if counter == none and title != none {
     header = [*#title.*]
-  }
-  else if counter != none and title == none {
+  } else if counter != none and title == none {
     header = [*#counter.*]
-  }
-  else {
+  } else {
     header = [*#counter:* #title.]
   }
 
@@ -134,29 +113,29 @@
 #let d = counter("definition")
 #let definition(content, title: none) = {
   d.step()
-  frame(counter: d.display(x => "Definition " + str(x)), title: title, content)
+  frame(counter: context d.display(x => "Definition " + str(x)), title: title, content)
 }
 
 #let t = counter("theorem")
 #let theorem(content, title: none) = {
   t.step()
-  frame(counter: t.display(x => "Theorem " + str(x)), title: title, content)
+  frame(counter: context t.display(x => "Theorem " + str(x)), title: title, content)
 }
 
 #let l = counter("lemma")
 #let lemma(content, title: none) = {
   l.step()
-  frame(counter: l.display(x => "Lemma " + str(x)), title: title, content)
+  frame(counter: context l.display(x => "Lemma " + str(x)), title: title, content)
 }
 
 #let c = counter("corollary")
 #let corollary(content, title: none) = {
   c.step()
-  frame(counter: c.display(x => "Corollary " + str(x)), title: title, content)
+  frame(counter: context c.display(x => "Corollary " + str(x)), title: title, content)
 }
 
 #let a = counter("algorithm")
 #let algorithm(content, title: none) = {
   a.step()
-  frame(counter: a.display(x => "Algorithm " + str(x)), title: title, content)
+  frame(counter: context a.display(x => "Algorithm " + str(x)), title: title, content)
 }

--- a/typst.toml
+++ b/typst.toml
@@ -1,7 +1,7 @@
 [package]
 name = "slydst"
-version = "0.1.1"
-compiler = "0.11.0"
+version = "0.1.2"
+compiler = "0.12.0"
 entrypoint = "lib.typ"
 authors = ["Gaspard Lambrechts <https://github.com/glambrechts>"]
 license = "MIT"


### PR DESCRIPTION
Hi Gaspard,

Using the latest version of the Typst compiler ([v0.12 Release Candidate](https://github.com/typst/typst/releases/tag/v0.12.0-rc1)), I found the following warnings when compiling a document:

```
warning: `counter.display` without context is deprecated
    ┌─ slydst.typ:116:17
    │
116 │   frame(counter: d.display(x => "Definition " + str(x)), title: title, content)
    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = hint: use it in a `context` expression instead

warning: `counter.display` without context is deprecated
    ┌─ slydst.typ:122:17
    │
122 │   frame(counter: t.display(x => "Theorem " + str(x)), title: title, content)
    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = hint: use it in a `context` expression instead

warning: `counter.display` without context is deprecated
    ┌─ slydst.typ:128:17
    │
128 │   frame(counter: l.display(x => "Lemma " + str(x)), title: title, content)
    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = hint: use it in a `context` expression instead

warning: `counter.display` without context is deprecated
    ┌─ slydst.typ:134:17
    │
134 │   frame(counter: c.display(x => "Corollary " + str(x)), title: title, content)
    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = hint: use it in a `context` expression instead

warning: `counter.display` without context is deprecated
   ┌─ slydst.typ:56:7
   │
56 │       #counter(page).display("1/1", both: true)
   │        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   │
   = hint: use it in a `context` expression instead
```

This happens because `display` without `context` will be deprecated for the next version, as the [v0.12 changelog](https://staging.typst.app/docs/changelog) indicates:

> Deprecations
>     - [counter.display](https://staging.typst.app/docs/reference/introspection/counter/#definitions-display) without an established context

You may not intend to add this change yet, as version 0.12 is not yet final, but I leave this pull request here in case you intend to accept it when the time comes.

I have also reformatted the code using [Typst LSP](https://github.com/nvarner/typst-lsp) formatter.

Thanks! :-)